### PR TITLE
Add Fedora (38) instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Ubuntu:
 sudo apt-get install libusb-1.0-0-dev libx11-dev libgl-dev
 ```
 
+Fedora:
+
+```bash
+sudo dnf install libusb1-devel libx11-devel mesa-libGL-devel
+```
+
 ## Compile
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ubuntu:
 sudo apt-get install libusb-1.0-0-dev libx11-dev libgl-dev
 ```
 
-Fedora:
+Fedora (38):
 
 ```bash
 sudo dnf install libusb1-devel libx11-devel mesa-libGL-devel


### PR DESCRIPTION
Let's just add the instructions on how to install the different required packages on Fedora 38, at least.